### PR TITLE
Add required Caddy ask endpoint for on-demand TLS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Be sure to replace `example.com` with your own domain.
 cat <<CADDYFILE | sudo tee /pds/caddy/etc/caddy/Caddyfile
 {
   email you@example.com
+  on_demand_tls {
+    ask http://localhost:3000
+  }
 }
 
 *.example.com, example.com {


### PR DESCRIPTION
[Caddy 2.7.3](https://github.com/caddyserver/caddy/releases/tag/v2.7.3) made it required to provide an ask endpoint for on-demand TLS. #8 reported an impact from that change, and 6e51174 added the ask endpoint to the Caddyfile created by the installer script. This PR adds the same ask endpoint to the manual installation instructions in the README.