### PR TITLE
Use PDS_ENV_FILE environment variable if set 

### DIFF
--- a/pdsadmin/account.sh
+++ b/pdsadmin/account.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PDS_ENV_FILE="/pds/pds.env"
+PDS_ENV_FILE=${PDS_ENV_FILE:-"/pds/pds.env"}
 source "${PDS_ENV_FILE}"
 
 # curl a URL and fail if the request fails.

--- a/pdsadmin/create-invite-code.sh
+++ b/pdsadmin/create-invite-code.sh
@@ -3,8 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PDS_ENV_FILE="/pds/pds.env"
-
+PDS_ENV_FILE=${PDS_ENV_FILE:-"/pds/pds.env"}
 source "${PDS_ENV_FILE}"
 
 curl \

--- a/pdsadmin/request-crawl.sh
+++ b/pdsadmin/request-crawl.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PDS_ENV_FILE="/pds/pds.env"
+PDS_ENV_FILE=${PDS_ENV_FILE:-"/pds/pds.env"}
 source "${PDS_ENV_FILE}"
 
 RELAY_HOSTS="${1:-}"


### PR DESCRIPTION
This PR instructs the account.sh, create-invite-code.sh, and request-crawl.sh scripts to use the environment variable PDS_ENV_FILE as the source of environment variable data if it is set. Otherwise, the default value is used.