### PR TITLE
Provide more information on pdsadmin error

### DIFF
--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -20,7 +20,8 @@ SCRIPT_URL="${PDSADMIN_BASE_URL}/${COMMAND}.sh"
 SCRIPT_FILE="$(mktemp /tmp/pdsadmin.${COMMAND}.XXXXXX)"
 
 if ! curl --fail --silent --show-error --location --output "${SCRIPT_FILE}" "${SCRIPT_URL}"; then
-  echo "ERROR: ${COMMAND} not found"
+  echo "ERROR: command '$0 ${COMMAND}' not found"
+  echo "Run '$0 help' for a list of commands"
   exit 2
 fi
 


### PR DESCRIPTION
When I was getting my test PDS set up I was confusing "you provided an invalid command" with "the resource on your PDS was not found". The error message was there, but my changes make it more clear to me. If you disagree feel free to close this!

It will now provide this help message:

```
bash pdsadmin.sh accdsddsd
curl: (22) The requested URL returned error: 404
ERROR: command 'pdsadmin.sh accdsddsd' not found
Run 'pdsadmin.sh help' for a list of commands
```

(with `pdsadmin.sh` being replaced by `pdsadmin` when run on a server, since it uses `$0`)