### PR TITLE
Fix pdsadmin account list on Ubuntu 20.04

### DIFF
--- a/pdsadmin/account.sh
+++ b/pdsadmin/account.sh
@@ -40,7 +40,7 @@ if [[ "${SUBCOMMAND}" == "list" ]]; then
     OUTPUT="${OUTPUT},${ITEM}"
   done
   OUTPUT="${OUTPUT}]"
-  echo "${OUTPUT}" | jq --raw-output '.[] | [.handle, .email, .did] | @tsv' | column --table
+  echo "${OUTPUT}" | jq --raw-output '.[] | [.handle, .email, .did] | @tsv' | column -t
 
 #
 # account create


### PR DESCRIPTION
Currently on Ubuntu 20.04 when running pdsadmin account list the command fails with the error `column: invalid option -- '-'`. On Ubuntu 20.04 the column command only accepts the -t. Later supported versions of Ubuntu and Debian support both --table and -t. So this change updates the list command to use -t for column to support all supported distributions.

See column manual pages for
- [Ubuntu 20.04](https://manpages.ubuntu.com/manpages/focal/en/man1/column.1.html)
- [Ubuntu 22.04](https://manpages.ubuntu.com/manpages/jammy/en/man1/column.1.html)
- [Debian 11](https://manpages.debian.org/bullseye/bsdextrautils/column.1.en.html)
- [Debian 12](https://manpages.debian.org/bookworm/bsdextrautils/column.1.en.html)