### PR TITLE
Added bsdmainutils to required system packages

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -31,6 +31,7 @@ REQUIRED_SYSTEM_PACKAGES="
   openssl
   sqlite3
   xxd
+  bsdmainutils
 "
 # Docker packages.
 REQUIRED_DOCKER_PACKAGES="


### PR DESCRIPTION
Fresh Ubuntu Server installs might be missing **column** which is required for **pdsadmin** to function. In my case it was missing due to a minimal install from a 22.04.4 ISO.

Installing the **bsdmainutils** package resolves this and I've added it as a required system package to the installer.