### PR TITLE
Fix migration instructions due to lxm

### DIFF
--- a/ACCOUNT_MIGRATION.md
+++ b/ACCOUNT_MIGRATION.md
@@ -107,6 +107,7 @@ const migrateAccount = async () => {
 
   const serviceJwtRes = await oldAgent.com.atproto.server.getServiceAuth({
     aud: newServerDid,
+    lxm: 'com.atproto.server.createAccount',
   })
   const serviceJwt = serviceJwtRes.data.token
 


### PR DESCRIPTION
Fixes #87 

The migration instructions have not been updated after implementation https://github.com/bluesky-social/atproto/pull/2663, so the instructions are broken.

Problem is that we have to use the `lxm` parameter when calling `atproto.server.getServiceAuth` to get the correct JWT.

 