### PR TITLE
Added 24.10 to accepted Ubuntu distribution releases

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -95,7 +95,10 @@ function main {
       echo "* Detected supported distribution Ubuntu 22.04 LTS"
     elif [[ "${DISTRIB_CODENAME}" == "mantic" ]]; then
       SUPPORTED_OS="true"
-      echo "* Detected supported distribution Ubuntu 23.10 LTS"
+      echo "* Detected supported distribution Ubuntu 23.10"
+    elif [[ "${DISTRIB_CODENAME}" == "noble" ]]; then
+      SUPPORTED_OS="true"
+      echo "* Detected supported distribution Ubuntu 24.04 LTS"
     fi
   elif [[ "${DISTRIB_ID}" == "debian" ]]; then
     if [[ "${DISTRIB_CODENAME}" == "bullseye" ]]; then


### PR DESCRIPTION
There doesn't seem to be anything in 24.04 that makes PDS stop working (#84) so I've added in to the installer.

Would appreciate someone with richer use of PDS than me to perform tests to verify that, though.