### PR TITLE
Correct verbiage of `untakedown` in pdsadmin help.

### DIFF
--- a/pdsadmin/help.sh
+++ b/pdsadmin/help.sh
@@ -25,7 +25,7 @@ account
     Takedown an account specified by DID.
     e.g. pdsadmin account takedown did:plc:xyz123abc456
   untakedown <DID>
-    Remove a takedown an account specified by DID.
+    Remove a takedown from an account specified by DID.
     e.g. pdsadmin account untakedown did:plc:xyz123abc456
   reset-password <DID>
     Reset a password for an account specified by DID.


### PR DESCRIPTION
Corrects the language for the untakedown command to read more fluently / grammatically correct.