### PR TITLE
Use portable shebangs

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/account.sh
+++ b/pdsadmin/account.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/create-invite-code.sh
+++ b/pdsadmin/create-invite-code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/help.sh
+++ b/pdsadmin/help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/request-crawl.sh
+++ b/pdsadmin/request-crawl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/update.sh
+++ b/pdsadmin/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
Use `#!/usr/bin/env bash` instead of `#!/bin/bash`. Some systems, like NixOS, do not have `bash` in `/bin`, `/usr/bin/env` will look up bash path instead