### PR TITLE
Update docker to not use host networking

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,11 @@
-version: '3.9'
+version: "3.9"
 services:
   caddy:
     container_name: caddy
     image: caddy:2
-    network_mode: host
+    ports:
+      - "80:80"
+      - "443:443"
     depends_on:
       - pds
     restart: unless-stopped
@@ -17,7 +19,6 @@ services:
   pds:
     container_name: pds
     image: ghcr.io/bluesky-social/pds:0.4
-    network_mode: host
     restart: unless-stopped
     volumes:
       - type: bind
@@ -28,7 +29,6 @@ services:
   watchtower:
     container_name: watchtower
     image: containrrr/watchtower:latest
-    network_mode: host
     volumes:
       - type: bind
         source: /var/run/docker.sock

--- a/installer.sh
+++ b/installer.sh
@@ -309,7 +309,7 @@ DOCKERD_CONFIG
 {
 	email ${PDS_ADMIN_EMAIL}
 	on_demand_tls {
-		ask http://localhost:3000/tls-check
+		ask http://pds:3000/tls-check
 	}
 }
 
@@ -317,7 +317,7 @@ DOCKERD_CONFIG
 	tls {
 		on_demand
 	}
-	reverse_proxy http://localhost:3000
+	reverse_proxy http://pds:3000
 }
 CADDYFILE
 


### PR DESCRIPTION
Explicitly forward required ports so the containers don't run with host networking which also causes the containers to run as privileged.