### PR TITLE
Limit watchtower scope and integrate better with systemd

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 services:
   caddy:
     container_name: caddy
@@ -14,6 +14,7 @@ services:
       - type: bind
         source: /pds/caddy/etc/caddy
         target: /etc/caddy
+    labels: ["com.centurylinklabs.watchtower.scope=bluesky"]
   pds:
     container_name: pds
     image: ghcr.io/bluesky-social/pds:0.4
@@ -25,6 +26,7 @@ services:
         target: /pds
     env_file:
       - /pds/pds.env
+    labels: ["com.centurylinklabs.watchtower.scope=bluesky"]
   watchtower:
     container_name: watchtower
     image: containrrr/watchtower:latest
@@ -37,3 +39,5 @@ services:
     environment:
       WATCHTOWER_CLEANUP: true
       WATCHTOWER_SCHEDULE: "@midnight"
+      WATCHTOWER_SCOPE: "bluesky"
+    labels: ["com.centurylinklabs.watchtower.scope=bluesky"]

--- a/installer.sh
+++ b/installer.sh
@@ -369,10 +369,9 @@ Requires=docker.service
 After=docker.service
 
 [Service]
-Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${PDS_DATADIR}
-ExecStart=/usr/bin/docker compose --file ${PDS_DATADIR}/compose.yaml up --detach
+ExecStart=/usr/bin/docker compose --file ${PDS_DATADIR}/compose.yaml up
 ExecStop=/usr/bin/docker compose --file ${PDS_DATADIR}/compose.yaml down
 
 [Install]


### PR DESCRIPTION
fixes #49

By not using oneshot service type and not detaching the docker compose command you can use normal systemd tools (e.g. journalctl) for logs. Docker commands still work too.