### PR TITLE
fix: rm should use the `-f` flag instead of force for compatibility with more systems

### DIFF
--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -26,5 +26,5 @@ fi
 
 chmod +x "${SCRIPT_FILE}"
 if "${SCRIPT_FILE}" "$@"; then
-  rm --force "${SCRIPT_FILE}"
+  rm -f "${SCRIPT_FILE}"
 fi


### PR DESCRIPTION
alpine for example does not recognize the force option
