### PR TITLE
pdsadmin.sh: TOFU, require permission for command updates

### DIFF
--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -7,6 +7,7 @@ PDSADMIN_BASE_URL="https://raw.githubusercontent.com/bluesky-social/pds/main/pds
 
 # Command to run.
 COMMAND="${1:-help}"
+SCRIPT_FILE="/pds/${COMMAND}.sh"
 shift || true
 
 # Ensure the user is root, since it's required for most commands.
@@ -17,14 +18,27 @@ fi
 
 # Download the script, if it exists.
 SCRIPT_URL="${PDSADMIN_BASE_URL}/${COMMAND}.sh"
-SCRIPT_FILE="$(mktemp /tmp/pdsadmin.${COMMAND}.XXXXXX)"
+UPDATE_FILE="$(mktemp /tmp/pdsadmin.${COMMAND}.XXXXXX)"
 
-if ! curl --fail --silent --show-error --location --output "${SCRIPT_FILE}" "${SCRIPT_URL}"; then
+if ! curl --fail --silent --show-error --location --output "${UPDATE_FILE}" "${SCRIPT_URL}"; then
   echo "ERROR: ${COMMAND} not found"
   exit 2
 fi
+chmod +x "${UPDATE_FILE}"
 
-chmod +x "${SCRIPT_FILE}"
-if "${SCRIPT_FILE}" "$@"; then
-  rm --force "${SCRIPT_FILE}"
+# Install the command on first use, else if modified ask permission to update it
+if [[ ! -f "${SCRIPT_FILE}" ]]; then
+  mv --force "${UPDATE_FILE}" "${SCRIPT_FILE}"
+elif ! cmp --quiet "${SCRIPT_FILE}" "${UPDATE_FILE}"; then
+  read -p "Update command \"${COMMAND}\" [yes]? " choice
+  case $choice in
+    ""|[Yy]* ) # Default allow
+      mv --force "${UPDATE_FILE}" "${SCRIPT_FILE}" 
+    ;;
+    * )
+      rm --force "${UPDATE_FILE}"
+    ;;
+    esac
 fi
+
+"${SCRIPT_FILE}" "$@"


### PR DESCRIPTION
Running code off the internet is not a healthy pattern. While a user might trust the repository at the time they first install the code, they should be aware of subsequent updates and have the opportunity to inspect them before running new code. This change provides a minimally intrusive prompt (defaulting to allow on hitting enter), and does not prompt on first installation.