### PR TITLE
Check if domain exists in manualCertSet for tls-check

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -40,7 +40,8 @@ async function checkHandleRoute(
         message: "bad or missing domain query param",
       });
     }
-    if (domain === pds.ctx.cfg.service.hostname) {
+    if (domain === pds.ctx.cfg.service.hostname
+      || pds.ctx.cfg.service.manualCertSet.has(domain)) {
       return res.json({ success: true });
     }
     const isHostedHandle = pds.ctx.cfg.identity.serviceHandleDomains.find(


### PR DESCRIPTION
**NOTE: This leverages the code being proposed on the atproto project found here:** https://github.com/bluesky-social/atproto/pull/3091

Allows for on-demand SSL generation based on manualCertSet in environment config.