### PR TITLE
Removes obsolete version property per docker-compose V2 spec

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   caddy:
     container_name: caddy


### PR DESCRIPTION
- Resolves warning when running docker-compose up
- [Official documentation](https://docs.docker.com/reference/compose-file/version-and-name/)