### PR TITLE
Change instances of `#!/bin/bash` to `#!/usr/bin/env bash`

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/account.sh
+++ b/pdsadmin/account.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/create-invite-code.sh
+++ b/pdsadmin/create-invite-code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/help.sh
+++ b/pdsadmin/help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/request-crawl.sh
+++ b/pdsadmin/request-crawl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pdsadmin/update.sh
+++ b/pdsadmin/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
Changes the shebang string to use the environment bash for when `/bin/bash` doesn't exist for whatever reason