### PR TITLE
Don't enforce /pds for PDS_DATADIR

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,10 +9,10 @@ services:
     restart: unless-stopped
     volumes:
       - type: bind
-        source: /pds/caddy/data
+        source: @PDS_DATADIR@/caddy/data
         target: /data
       - type: bind
-        source: /pds/caddy/etc/caddy
+        source: @PDS_DATADIR@/caddy/etc/caddy
         target: /etc/caddy
   pds:
     container_name: pds
@@ -21,10 +21,10 @@ services:
     restart: unless-stopped
     volumes:
       - type: bind
-        source: /pds
+        source: @PDS_DATADIR@
         target: /pds
     env_file:
-      - /pds/pds.env
+      - @PDS_DATADIR@/pds.env
   watchtower:
     container_name: watchtower
     image: containrrr/watchtower:latest

--- a/installer.sh
+++ b/installer.sh
@@ -112,12 +112,6 @@ function main {
     exit 1
   fi
 
-  # Enforce that the data directory is /pds since we're assuming it for now.
-  # Later we can make this actually configurable.
-  if [[ "${PDS_DATADIR}" != "/pds" ]]; then
-    usage "The data directory must be /pds. Exiting..."
-  fi
-
   # Check if PDS is already installed.
   if [[ -e "${PDS_DATADIR}/pds.sqlite" ]]; then
     echo
@@ -354,8 +348,8 @@ PDS_CONFIG
     --output "${PDS_DATADIR}/compose.yaml" \
     "${COMPOSE_URL}"
 
-  # Replace the /pds paths with the ${PDS_DATADIR} path.
-  sed --in-place "s|/pds|${PDS_DATADIR}|g" "${PDS_DATADIR}/compose.yaml"
+  # Replace the @PDS_DATADIR@ paths with the ${PDS_DATADIR} path.
+  sed --in-place "s|@PDS_DATADIR@|${PDS_DATADIR}|g" "${PDS_DATADIR}/compose.yaml"
 
   #
   # Create the systemd service.

--- a/pdsadmin/update.sh
+++ b/pdsadmin/update.sh
@@ -3,7 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PDS_DATADIR="/pds"
+PDS_ENV_FILE=${PDS_ENV_FILE:-"/pds/pds.env"}
+source "${PDS_ENV_FILE}"
+
 COMPOSE_FILE="${PDS_DATADIR}/compose.yaml"
 COMPOSE_URL="https://raw.githubusercontent.com/bluesky-social/pds/main/compose.yaml"
 
@@ -19,6 +21,9 @@ curl \
   --fail \
   --output "${COMPOSE_TEMP_FILE}" \
   "${COMPOSE_URL}"
+
+# Replace the /pds paths with the ${PDS_DATADIR} path.
+sed --in-place "s|@PDS_DATADIR@|${PDS_DATADIR}|g" "${COMPOSE_TEMP_FILE}"
 
 if cmp --quiet "${COMPOSE_FILE}" "${COMPOSE_TEMP_FILE}"; then
   echo "PDS is already up to date"


### PR DESCRIPTION
This removes the last vestiges that forced /pds to be the hosted
data directory.

Note that this makes compose.yaml not possible to use directly, as
@PDS_DATADIR@ must now be replaced with the actual data directory.
However, since it was already manipulated by installer.sh, this was
obviously already intended, just not completed.
