### PR TITLE
[FIX]  pnpm Lockfile is not compatible / Dockerbuild errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.11-alpine3.18 AS build
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 # Move files into the image and install
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11-alpine3.18 as build
+FROM node:20.11-alpine3.18 AS build
 
 RUN npm install -g pnpm
 


### PR DESCRIPTION
Two problem while building Dockerfile:
- Error: the pnpm lockfile is not compatible (made with version 9), actual Version is 10
- Warning: FromAsCasing: 'as' and 'FROM' keywords' casing do not match