### PR TITLE
Switch build to use corepack rather than latest pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:20.11-alpine3.18 as build
 
-RUN npm install -g pnpm
+RUN corepack enable
 
 # Move files into the image and install
 WORKDIR /app
 COPY ./service ./
+RUN corepack prepare --activate
 RUN pnpm install --production --frozen-lockfile > /dev/null
 
 # Uses assets from build stage to reduce build size

--- a/service/package.json
+++ b/service/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "description": "Service entrypoint for atproto personal data server",
+  "packageManager": "pnpm@8.15.9",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This should break the build issue on `main`, which is a result of the pnpm-lock version being incompatible with the latest version of pnpm.  By using corepack we'll always use a compatible version of pnpm.