### PR TITLE
Ubuntu 24.04 support, erroneous 23.10 removal, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Head over to the [AT Protocol PDS Admins Discord](https://discord.gg/e7hpHxRfBP)
   * [Open your cloud firewall for HTTP and HTTPS](#open-your-cloud-firewall-for-http-and-https)
   * [Configure DNS for your domain](#configure-dns-for-your-domain)
   * [Check that DNS is working as expected](#check-that-dns-is-working-as-expected)
-  * [Installer on Ubuntu 20.04/22.04 and Debian 11/12](#installer-on-ubuntu-20042204-and-debian-1112)
+  * [Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12](#installer-on-ubuntu-200422042404-and-debian-1112)
   * [Verifying that your PDS is online and accessible](#verifying-that-your-pds-is-online-and-accessible)
   * [Creating an account using pdsadmin](#creating-an-account-using-pdsadmin)
   * [Creating an account using an invite code](#creating-an-account-using-an-invite-code)
@@ -83,7 +83,7 @@ Ensure that you can ssh to your server and have root access.
 **Server Recommendations**
 |                  |              |
 | ---------------- | ------------ |
-| Operating System | Ubuntu 22.04 |
+| Operating System | Ubuntu 24.04 |
 | Memory (RAM)     | 1 GB         |
 | CPU Cores        | 1            |
 | Storage          | 20 GB SSD    |
@@ -130,7 +130,7 @@ Examples to check (record type `A`):
 
 These should all return your server's public IP.
 
-### Installer on Ubuntu 20.04/22.04 and Debian 11/12
+### Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12
 
 On your server via ssh, download the installer script using wget:
 

--- a/installer.sh
+++ b/installer.sh
@@ -94,9 +94,9 @@ function main {
     elif [[ "${DISTRIB_CODENAME}" == "jammy" ]]; then
       SUPPORTED_OS="true"
       echo "* Detected supported distribution Ubuntu 22.04 LTS"
-    elif [[ "${DISTRIB_CODENAME}" == "mantic" ]]; then
+    elif [[ "${DISTRIB_CODENAME}" == "noble" ]]; then
       SUPPORTED_OS="true"
-      echo "* Detected supported distribution Ubuntu 23.10 LTS"
+      echo "* Detected supported distribution Ubuntu 24.04 LTS"
     fi
   elif [[ "${DISTRIB_ID}" == "debian" ]]; then
     if [[ "${DISTRIB_CODENAME}" == "bullseye" ]]; then
@@ -109,7 +109,7 @@ function main {
   fi
 
   if [[ "${SUPPORTED_OS}" != "true" ]]; then
-    echo "Sorry, only Ubuntu 20.04, 22.04, Debian 11 and Debian 12 are supported by this installer. Exiting..."
+    echo "Sorry, only Ubuntu 20.04, 22.04, 24.04, Debian 11 and Debian 12 are supported by this installer. Exiting..."
     exit 1
   fi
 


### PR DESCRIPTION
I initilly made these changes to the installer script on my PDS, and I've run into no issues.

This PR is similar to #98, but I decided the mention of `23.10 LTS` in the installer was a mistake and changed the code accordingly (23.10 is not actually an LTS release). I updated the `README.md` to reflect these changes.

Resolves #84.
