### PR TITLE
Remove Duplication Installer Dependency

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -31,7 +31,6 @@ REQUIRED_SYSTEM_PACKAGES="
   openssl
   sqlite3
   xxd
-  jq
 "
 # Docker packages.
 REQUIRED_DOCKER_PACKAGES="


### PR DESCRIPTION
Was just looking at the install script and noticed `jq` is defined twice in the list of dependency packages.