### PR TITLE
Change --force to -f for compatibility

### DIFF
--- a/pdsadmin.sh
+++ b/pdsadmin.sh
@@ -26,5 +26,5 @@ fi
 
 chmod +x "${SCRIPT_FILE}"
 if "${SCRIPT_FILE}" "$@"; then
-  rm --force "${SCRIPT_FILE}"
+  rm -f "${SCRIPT_FILE}"
 fi


### PR DESCRIPTION
Docker image runs BusyBox, if we want to run pdsadmin from within the docker image, rm --force will fail. Changed to rm -f as it is the POSIX way.