### PR TITLE
SMTP and special characters may need percent encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ _Note: Your PDS will need to be restarted with those variables. This varies depe
 
 If you find that your test messages using cURL or other sources go out correctly, but you are not receiving emails from your PDS, you may need to URL encode your username and password on `/pds/pds.env` and restart the PDS service.
 
-If the username and/or password contain special characters, the special characters will need to be [percent encoded](https://en.wikipedia.org/wiki/Percent-encoding).  For some email services, the username will contain an extra `@` symbol that will also need to be percent encoded. For example, the URL `user&name@oci:p@ssword@smtphost:465` after percent encoding for the username and password fields would become `user%26name%40oci:p%40ssword@smtphost:465`.
+If the username and/or password contain special characters, the special characters may need to be [percent encoded](https://en.wikipedia.org/wiki/Percent-encoding).  For some email services, the username will contain an extra `@` symbol that may also need to be percent encoded. For example, the URL `user&name@oci:p@ssword@smtphost:465` after percent encoding for the username and password fields would become `user%26name%40oci:p%40ssword@smtphost:465`.
 
 If you are migrating an account, Bluesky's UI will ask you to confirm your email address. The confirmation code email is meant to come from your PDS. If you are encountering issues with SMTP and want to confirm the address before solving it, you can find the confirmation code on the `email_token` table on `accounts.sqlite`.
 


### PR DESCRIPTION
As seen in issues like https://github.com/bluesky-social/pds/issues/200  , percent encoding may be needed on some occasions, while in others it won't work at all.

Updated README.md to not sound like percent enconding is the only way to make it work.