### PR TITLE
Add Debian 13 as a supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Head over to the [AT Protocol PDS Admins Discord](https://discord.gg/e7hpHxRfBP)
   * [Open your cloud firewall for HTTP and HTTPS](#open-your-cloud-firewall-for-http-and-https)
   * [Configure DNS for your domain](#configure-dns-for-your-domain)
   * [Check that DNS is working as expected](#check-that-dns-is-working-as-expected)
-  * [Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12](#installer-on-ubuntu-200422042404-and-debian-1112)
+  * [Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12/13](#installer-on-ubuntu-200422042404-and-debian-111213)
   * [Verifying that your PDS is online and accessible](#verifying-that-your-pds-is-online-and-accessible)
   * [Creating an account using pdsadmin](#creating-an-account-using-pdsadmin)
   * [Creating an account using an invite code](#creating-an-account-using-an-invite-code)
@@ -130,7 +130,7 @@ Examples to check (record type `A`):
 
 These should all return your server's public IP.
 
-### Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12
+### Installer on Ubuntu 20.04/22.04/24.04 and Debian 11/12/13
 
 On your server via ssh, download the installer script using wget:
 

--- a/installer.sh
+++ b/installer.sh
@@ -105,11 +105,14 @@ function main {
     elif [[ "${DISTRIB_CODENAME}" == "bookworm" ]]; then
       SUPPORTED_OS="true"
       echo "* Detected supported distribution Debian 12"
+	elif [[ "${DISTRIB_CODENAME}" == "trixie" ]]; then
+      SUPPORTED_OS="true"
+      echo "* Detected supported distribution Debian 13"
     fi
   fi
 
   if [[ "${SUPPORTED_OS}" != "true" ]]; then
-    echo "Sorry, only Ubuntu 20.04, 22.04, 24.04, Debian 11 and Debian 12 are supported by this installer. Exiting..."
+    echo "Sorry, only Ubuntu 20.04, 22.04, 24.04, Debian 11, Debian 12 and Debian 13 are supported by this installer. Exiting..."
     exit 1
   fi
 


### PR DESCRIPTION
Debian 13 released on August 9th, 2025. That's nearly two months ago at the time of writing.

I ran the installer on Debian 13 and the PDS is working as expected.