### PR TITLE
switch to watchtower fork

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ services:
       - /pds/pds.env
   watchtower:
     container_name: watchtower
-    image: containrrr/watchtower:latest
+    image: ghcr.io/nicholas-fedor/watchtower:latest
     network_mode: host
     volumes:
       - type: bind


### PR DESCRIPTION
I normally don't switch to a 3rd party fork lightly due to maintenance implications, but this seems like the right move here: https://github.com/containrrr/watchtower/issues/2122

Tested that the fork was able to update gracefully from 0.4.188 -> 0.4.193.