### PR TITLE
Add PDS_TERMS_OF_SERVICE_URL to the Environment Variable table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ From your DNS provider's control panel, set up a domain with records pointing to
 **Note:**
 * Replace `example.com` with your domain name.
 * Replace `12.34.56.78` with your server's IP address.
-* Some providers (such as Cloudflare) may use the `@` symbol to represent the root of your domain.
+* Some providers may use the `@` symbol to represent the root of your domain.
 * The wildcard record is required when allowing users to create new accounts on your PDS.
 * The TTL can be anything but 600 (10 minutes) is reasonable
 


### PR DESCRIPTION
Add the `PDS_TERMS_OF_SERVICE_URL` environment variable to [the environment variable table in README.md](https://github.com/bluesky-social/pds?tab=readme-ov-file#environment-variables). With the default set to `none`.

Add Cloudflare as an example DNS provider that uses the `@` symbol to represent the root domain in the [README.md](https://github.com/bluesky-social/pds?tab=readme-ov-file#environment-variables:~:text=Some%20providers%20may%20use%20the%20%40%20symbol%20to%20represent%20the%20root%20of%20your%20domain)