### PR TITLE
make sure update script always actually updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ LOG_LEVEL=debug
 
 ### Updating your PDS
 
-It is recommended that you keep your PDS up to date with new versions. You can use the `pdsadmin` tool to update your PDS.
+It is recommended that you keep your PDS up to date with new versions. This repo sets up [watchtower](https://github.com/nicholas-fedor/watchtower), which handles automatic updates. You can also use the `pdsadmin` tool to manually update your PDS.
 
 ```bash
 sudo pdsadmin update

--- a/pdsadmin/update.sh
+++ b/pdsadmin/update.sh
@@ -20,16 +20,17 @@ curl \
   --output "${COMPOSE_TEMP_FILE}" \
   "${COMPOSE_URL}"
 
-sed --in-place "s|/pds|${PDS_DATADIR}|g" "${PDS_DATADIR}/compose.yaml"
+sed --in-place "s|/pds|${PDS_DATADIR}|g" "${COMPOSE_TEMP_FILE}"
 
-if cmp --quiet "${COMPOSE_FILE}" "${COMPOSE_TEMP_FILE}"; then
-  echo "PDS is already up to date"
+if ! cmp --quiet "${COMPOSE_FILE}" "${COMPOSE_TEMP_FILE}"; then
+  echo "* Updating PDS compose file"
+  mv "${COMPOSE_TEMP_FILE}" "${COMPOSE_FILE}"
+else
   rm --force "${COMPOSE_TEMP_FILE}"
-  exit 0
 fi
 
-echo "* Updating PDS"
-mv "${COMPOSE_TEMP_FILE}" "${COMPOSE_FILE}"
+echo "* Pulling latest PDS image"
+docker compose --project-directory "${PDS_DATADIR}" pull
 
 echo "* Restarting PDS"
 systemctl restart pds


### PR DESCRIPTION
For anyone still using update.sh rather than relying on Watchtower, I just realized this wouldn't necessarily always pull the latest image (managed to get into a situation just now where it *downgraded* the image running on my test instance), this should fix it.