### PR TITLE
Update PDS image tag to latest version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
         target: /etc/caddy
   pds:
     container_name: pds
-    image: ghcr.io/bluesky-social/pds:0.4
+    image: ghcr.io/bluesky-social/pds:latest
     network_mode: host
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
The version being pinned at `:0.4` is the reason why the new [`0.5.6` release of @atproto/pds](https://npmx.dev/package/@atproto/pds) is tagged as `0.4.5006` in the docker releases.

We should update to `:latest` which always tracks the current version, not a specific minor.

This will require folks to manually update their docker-compose.yaml, much like for the switch to latest watchtower that works — maybe we should do a small `upgrade.sh` script too that people can curl alongside the installer?