### PR TITLE
Document appearance customization env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Head over to the [ATProto Touchers Discord](https://discord.atprotocol.dev/) to 
     - [Logging](#logging)
     - [Updating your PDS](#updating-your-pds)
     - [Environment Variables](#environment-variables)
+    - [Customizing the appearance](#customizing-the-appearance)
     - [Migrating your PDS](#migrating-your-pds)
     - [Fixing a Relay desync](#fixing-a-relay-desync)
   - [License](#license)
@@ -352,6 +353,65 @@ sudo pdsadmin update
 | `PDS_TERMS_OF_SERVICE_URL`                  | None                               |
 | `PDS_RATE_LIMITS_ENABLED`                   | `true`                             |
 | `PDS_INVITE_REQUIRED`                       | `true`                             |
+
+### Customizing the appearance
+
+Your PDS serves the sign-in, sign-up, authorization, and account-management screens. You can brand them with your service's name, logo, colors, and background by adding any of these to `pds.env`. **All are optional.** Unset colors fall back to the stock palette in the table below (a `#8338ec` primary), the service name defaults to `<hostname> PDS`, and the logo, footer links, and background simply don't appear.
+
+**Name, logo & footer links**
+
+| Environment Variable       | Description                                                 |
+| -------------------------- | ----------------------------------------------------------- |
+| `PDS_SERVICE_NAME`         | Name shown on the auth screens (defaults to `<hostname> PDS`). |
+| `PDS_LOGO_URL`             | URL of a logo image shown above the sign-in card.           |
+| `PDS_HOME_URL`             | "Home" footer link.                                         |
+| `PDS_PRIVACY_POLICY_URL`   | "Privacy Policy" footer link.                               |
+| `PDS_TERMS_OF_SERVICE_URL` | "Terms of Service" footer link.                             |
+| `PDS_SUPPORT_URL`          | "Support" footer link.                                      |
+
+**Colors.** Each accepts any CSS color, e.g. `#1083fe` or `rgb(16 131 254)`.
+
+| Environment Variable | Description                                 | Default   |
+| -------------------- | ------------------------------------------- | --------- |
+| `PDS_PRIMARY_COLOR`  | Accent for buttons, links, and focus rings. | `#8338ec` |
+| `PDS_ERROR_COLOR`    | Error states.                               | `#dc2626` |
+| `PDS_WARNING_COLOR`  | Warnings.                                   | `#ffab0f` |
+| `PDS_INFO_COLOR`     | Informational notices.                      | `#007aff` |
+| `PDS_SUCCESS_COLOR`  | Success states.                             | `#17cc88` |
+
+<details><summary>Advanced color controls (rarely needed)</summary>
+
+| Environment Variable         | Description                                                                              | Example   |
+| ---------------------------- | --------------------------------------------------------------------------------------- | --------- |
+| `PDS_PRIMARY_COLOR_CONTRAST` | Text color placed on the primary color. Auto-derived from `PDS_PRIMARY_COLOR` if unset. | `#ffffff` |
+| `PDS_PRIMARY_COLOR_HUE`      | Hue (0–360) used when deriving contrast colors. Auto-derived if unset.                  | `265`     |
+| `PDS_LIGHT_COLOR`            | Light contrast endpoint used to pick readable text colors.                              | `#f8f8f8` |
+| `PDS_DARK_COLOR`             | Dark contrast endpoint used to pick readable text colors.                               | `#111111` |
+| `PDS_CONTRAST_SATURATION`    | Saturation (0–100) of the derived contrast colors.                                      | `30`      |
+
+</details>
+
+**Background images**
+
+| Environment Variable       | Description                                               |
+| -------------------------- | -------------------------------------------------------- |
+| `PDS_BACKGROUND_LIGHT_URL` | Image URL painted behind the auth card in **light** mode. |
+| `PDS_BACKGROUND_DARK_URL`  | Image URL painted behind the auth card in **dark** mode.  |
+
+The image fills the area behind the card (`cover`, centered) and is chosen by the visitor's light/dark preference. The card keeps its own opaque surface, so text stays legible over any image.
+
+**Tips:** Any common web image format works (WebP, AVIF, JPEG, PNG, SVG). Host it at a public **HTTPS** URL; like `PDS_LOGO_URL`, the auth pages only load images over `https:`. It loads on every sign-in and is scaled to fill the screen, so keep it lean: a well-compressed image around 2000px wide and comfortably under 1 MB (a few hundred KB is ideal). Keep important detail away from the edges, since the image is cropped to fill.
+
+**Example**
+
+```bash
+# Appearance
+PDS_SERVICE_NAME="Alice's PDS"
+PDS_LOGO_URL="https://example.com/logo.png"
+PDS_PRIMARY_COLOR="#1083fe"
+PDS_BACKGROUND_LIGHT_URL="https://example.com/bg-light.jpg"
+PDS_BACKGROUND_DARK_URL="https://example.com/bg-dark.jpg"
+```
 
 ### Migrating your PDS
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Your PDS serves the sign-in, sign-up, authorization, and account-management scre
 
 | Environment Variable | Description                                 | Default   |
 | -------------------- | ------------------------------------------- | --------- |
-| `PDS_PRIMARY_COLOR`  | Accent for buttons, links, and focus rings. | `#8338ec` |
+| `PDS_PRIMARY_COLOR`  | Accent for buttons and focus rings.         | `#8338ec` |
 | `PDS_ERROR_COLOR`    | Error states.                               | `#dc2626` |
 | `PDS_WARNING_COLOR`  | Warnings.                                   | `#ffab0f` |
 | `PDS_INFO_COLOR`     | Informational notices.                      | `#007aff` |

--- a/README.md
+++ b/README.md
@@ -377,18 +377,6 @@ Your PDS serves the sign-in, sign-up, authorization, and account-management scre
 | `PDS_INFO_COLOR`     | Informational notices.                      | `#007aff` |
 | `PDS_SUCCESS_COLOR`  | Success states.                             | `#17cc88` |
 
-<details><summary>Advanced color controls (rarely needed)</summary>
-
-| Environment Variable         | Description                                                                              | Example   |
-| ---------------------------- | --------------------------------------------------------------------------------------- | --------- |
-| `PDS_PRIMARY_COLOR_CONTRAST` | Text color placed on the primary color. Auto-derived from `PDS_PRIMARY_COLOR` if unset. | `#ffffff` |
-| `PDS_PRIMARY_COLOR_HUE`      | Hue (0–360) used when deriving contrast colors. Auto-derived if unset.                  | `265`     |
-| `PDS_LIGHT_COLOR`            | Light contrast endpoint used to pick readable text colors.                              | `#f8f8f8` |
-| `PDS_DARK_COLOR`             | Dark contrast endpoint used to pick readable text colors.                               | `#111111` |
-| `PDS_CONTRAST_SATURATION`    | Saturation (0–100) of the derived contrast colors.                                      | `30`      |
-
-</details>
-
 **Background images**
 
 | Environment Variable       | Description                                               |

--- a/README.md
+++ b/README.md
@@ -349,8 +349,6 @@ sudo pdsadmin update
 | `PDS_EMAIL_SMTP_URL`                        | None                               |
 | `PDS_EMAIL_FROM_ADDRESS`                    | None                               |
 | `PDS_CONTACT_EMAIL_ADDRESS`                 | None                               |
-| `PDS_PRIVACY_POLICY_URL`                    | None                               |
-| `PDS_TERMS_OF_SERVICE_URL`                  | None                               |
 | `PDS_RATE_LIMITS_ENABLED`                   | `true`                             |
 | `PDS_INVITE_REQUIRED`                       | `true`                             |
 
@@ -400,7 +398,7 @@ Your PDS serves the sign-in, sign-up, authorization, and account-management scre
 
 The image fills the area behind the card (`cover`, centered) and is chosen by the visitor's light/dark preference. The card keeps its own opaque surface, so text stays legible over any image.
 
-**Tips:** Any common web image format works (WebP, AVIF, JPEG, PNG, SVG). Host it at a public **HTTPS** URL; like `PDS_LOGO_URL`, the auth pages only load images over `https:`. It loads on every sign-in and is scaled to fill the screen, so keep it lean: a well-compressed image around 2000px wide and comfortably under 1 MB (a few hundred KB is ideal). Keep important detail away from the edges, since the image is cropped to fill.
+**Tips:** Any common web image format works (WebP, AVIF, JPEG, PNG, SVG). Host it at a public **HTTPS** URL; like `PDS_LOGO_URL`, the auth pages only load images over `https:`. It loads on every sign-in and is scaled to fill the screen. Use a well-compressed image around 2000px wide and comfortably under 1 MB (a few hundred KB is ideal). Keep important detail away from the edges, since the image is cropped to fill.
 
 **Example**
 


### PR DESCRIPTION
Documents the appearance customization env vars (name, logo, colors, background) for the OAuth screens.

Background image support: bluesky-social/atproto#5305
