### PR TITLE
ci: validate Docker dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 5
+    groups:
+      docker-base-images:
+        group-by: dependency-name
+        patterns:
+          - "*"
+    ignore:
+      # Node 26 reaches LTS on 2026-10-28. Remove via bluesky-social/.github#18.
+      - dependency-name: node
+        versions:
+          - ">= 26"
+
+  - package-ecosystem: docker-compose
+    directories:
+      - "/"
+      - "/monitoring"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 5
+    groups:
+      compose-images:
+        group-by: dependency-name
+        patterns:
+          - "*"
+    ignore:
+      # The application image is released by this repository.
+      - dependency-name: ghcr.io/bluesky-social/pds

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -1,5 +1,9 @@
 name: build-and-push-ghcr
 on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/build-and-push-ghcr.yaml
   push:
     branches:
       - main
@@ -24,13 +28,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME }}
@@ -49,7 +54,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Adds weekly Docker and Compose image updates and builds Dockerfile changes on pull requests.

Also moves the container workflow off retired action runtimes. Node 26 stays blocked until its October LTS date.