### PR TITLE
fix: keep Docker images on Node LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,11 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Node 26 reaches LTS on 2026-10-28. Remove via bluesky-social/.github#18.
+      # Stay on LTS Node 24. Node 25 is EOL; Node 26 reaches LTS on 2026-10-28.
+      # Remove via bluesky-social/.github#18.
       - dependency-name: node
         versions:
-          - ">= 26"
+          - ">= 25"
 
   - package-ecosystem: docker-compose
     directories:


### PR DESCRIPTION
Blocks Node 25 and pre-LTS Node 26 while allowing stale images to move to supported LTS releases.

Remove the guard through bluesky-social/.github#18 when Node 26 reaches LTS.